### PR TITLE
fixing error_code 999, due to missing accept-encoding header in fetch…

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -1,7 +1,7 @@
 var fs    = require('fs');
 var Wreck = require('wreck');
 var wreck = Wreck.defaults({
-    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 5.1; rv:19.0) Gecko/20100101 Firefox/19.0' }
+    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 5.1; rv:19.0) Gecko/20100101 Firefox/19.0', 'accept-encoding': 'html/text' }
 });
 
 /**


### PR DESCRIPTION
This PR contains fix for access_denied while accessing linkedin public profile pages.